### PR TITLE
Support for Critical events under Version2 Nessus files

### DIFF
--- a/lib/nessus/Version2/event.rb
+++ b/lib/nessus/Version2/event.rb
@@ -87,7 +87,7 @@ module Nessus
       # @return [Boolean]
       #   Return true if the event is critical severity.
       #
-      def high?
+      def critical?
         severity == 4
       end
       


### PR DESCRIPTION
I'm unsure if Version2 Nessus files currently support Critical events. I've been using a similar local copy of this gem for our https://github.com/AsteriskLabs/prenus project, but, I'm hoping if this change is merged, we can similar refer to your gem.

Cheers, Christian.
