### PR TITLE
Update version2.rb

### DIFF
--- a/lib/nessus/Version2/version2.rb
+++ b/lib/nessus/Version2/version2.rb
@@ -98,7 +98,7 @@ module Nessus
       #   The Hosts of the scan.
       #
       def hosts
-        Enumerator.new(self,:each_host).to_a
+        self.to_enum(:each_host).to_a
       end
 
       #


### PR DESCRIPTION
Fixed deprecated call to Enumerator "Enumerator.new without a block is deprecated; use Object#to_enum"