### PR TITLE
Add TARGET hosts

### DIFF
--- a/lib/nessus/Version1/version1.rb
+++ b/lib/nessus/Version1/version1.rb
@@ -127,6 +127,21 @@ module Nessus
       end
 
       #
+      # Return the hosts the were targeted for the initial scan.
+      # These are the hosts that were inputed when creating the scan.
+      #
+      # @return [Array<String>]
+      #   Array of hosts
+      #
+      def target_hosts
+        hosts = []
+        @xml.xpath('//Targets/Target/value').each do |element|
+          hosts << element.inner_text
+        end
+        hosts.sort.uniq!
+      end
+
+      #
       # Returns and array of the plugin ids userd for the passed .nessus scan.
       #
       # @return [Array]

--- a/lib/nessus/Version2/version2.rb
+++ b/lib/nessus/Version2/version2.rb
@@ -69,6 +69,21 @@ module Nessus
       def policy_notes
         @policy_notes ||= @xml.at("//Policy/policyComments").inner_text
       end
+      
+      #
+      # Return the hosts the were targeted for the initial scan.
+      # These are the hosts that were inputed when creating the scan.
+      #
+      # @return [Array<String>]
+      #   Array of hosts
+      #
+      def target_hosts
+        @xml.xpath('//Preferences/ServerPreferences/preference').each do |element|
+          if element.children[0].inner_text == 'TARGET'
+            return element.children[2].inner_text.split(',')
+          end
+        end
+      end
 
       #
       # Creates a new Host object to be parser


### PR DESCRIPTION
Allows you to see what hosts were targeted during the scan.  This can then be compared to what was actually scanned.

Saw https://github.com/mephux/ruby-nessus/issues/13 and tried to tackle it.

Not that familiar with Nokogiri, let me know if there is an easier way to get the targets in v2.  

I don't have any v1 reports, but used the one in the examples.  The code does pull the target out, but i'm not sure if it works with multiples.