### PR TITLE
Avoid "Using Enumerator.new without a block" warning

### DIFF
--- a/lib/nessus/Version1/host.rb
+++ b/lib/nessus/Version1/host.rb
@@ -249,7 +249,7 @@ module Nessus
       # @return [Array<String>]
       #   The events of the host.
       def events
-        Enumerator.new(self,:each_event).to_a
+        self.to_enum(:each_event).to_a
       end
 
 

--- a/lib/nessus/Version1/version1.rb
+++ b/lib/nessus/Version1/version1.rb
@@ -216,7 +216,7 @@ module Nessus
       #   The Hosts of the scan.
       #
       def hosts
-        Enumerator.new(self,:each_host).to_a
+        self.to_enum(:each_host).to_a
       end
 
       #

--- a/lib/nessus/Version2/host.rb
+++ b/lib/nessus/Version2/host.rb
@@ -255,7 +255,7 @@ module Nessus
       end
 
       def medium_severity
-        Enumerator.new(self,:medium_severity_events).to_a
+        self.to_enum(:medium_severity_events).to_a
       end
 
       #
@@ -359,7 +359,7 @@ module Nessus
       #   The events of the host.
       #
       def events
-        Enumerator.new(self,:each_event).to_a
+        self.to_enum(:each_event).to_a
       end
 
       #


### PR DESCRIPTION
Enumerator.new without a block it's deprecated and shows a warning, at least on my ruby 2.2.3p173.
It is solved using Object#to_enum.