### PR TITLE
Add false result for cve & bid

### DIFF
--- a/lib/ruby-nessus/Version2/event.rb
+++ b/lib/ruby-nessus/Version2/event.rb
@@ -288,6 +288,7 @@ module RubyNessus
           @event.xpath("cve").each do |cve|
             @cve << cve.inner_text
           end
+          @cve = false if @cve.empty?
         end
         @cve
       end
@@ -304,6 +305,7 @@ module RubyNessus
           @event.xpath("bid").each do |bid|
             @bid << bid.inner_text
           end
+          @bid = false if @bid.empty?
         end
         @bid
       end


### PR DESCRIPTION
The specs for cve and bid were failing, because they were returning []
instead of false, when there was no info for them in the event. This
changes the method to behave as it is specified in the documentation
above the methods and in the specs.