### PR TITLE
The yard dependency defined in ruby-nessus.gemspec has a known high s…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ruby-nessus (2.0.beta)
       nokogiri (~> 1.4)
-      rainbow (~> 2.0)
+      rainbow (>= 2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -71,7 +71,7 @@ DEPENDENCIES
   rubocop (~> 0.51)
   ruby-nessus!
   rubygems-tasks (~> 0.1)
-  yard (~> 0.7)
+  yard (~> 0.9.11)
 
 BUNDLED WITH
    1.16.0

--- a/ruby-nessus.gemspec
+++ b/ruby-nessus.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~> 3.7'
   gem.add_development_dependency 'rubocop', '~> 0.51'
   gem.add_development_dependency 'rubygems-tasks', '~> 0.1'
-  gem.add_development_dependency 'yard', '~> 0.7'
+  gem.add_development_dependency 'yard', '~> 0.9.11'
 end


### PR DESCRIPTION
…everity security vulnerability in version range < 0.9.11 and should be updated.

Signed-off-by: Florian Wininger <florian@cyberwatch.fr>