### PR TITLE
Provide access to ReportName `name` attribute in Host

### DIFF
--- a/lib/ruby-nessus/version2/host.rb
+++ b/lib/ruby-nessus/version2/host.rb
@@ -21,6 +21,10 @@ module RubyNessus
         ip.to_s
       end
 
+      def name
+        @host["name"]
+      end
+
       #
       # Return the Host Object hostname.
       #
@@ -33,7 +37,6 @@ module RubyNessus
       def hostname
         @host.at('tag[name=host-fqdn]')&.inner_text
       end
-      alias name hostname
       alias fqdn hostname
       alias dns_name hostname
 


### PR DESCRIPTION
Hi @mephux,

Small change here to provide access to the `name` attribute of the ReportHost field in the .nessus output. The reason why you might want access to this is because if you feed a valid FQDN (like `hello.example.com` to Nessus (and that host happens to have multiple FQDN entries, e.g. something like `xxxx.bc.googleusercontent.com` if hosted on google cloud), `tag[name=host-fqdn]` will actually contain the `xxxx.bc.googleusercontent.com` entry rather than the FQDN `hello.example.com` that you specified when you set up the scan in Nessus...

Make sense?